### PR TITLE
Improve API start-up without FMP key

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following environment variables are required:
 
 - `NEWS_API_KEY`: API key for NewsAPI
 - `ALPHA_VANTAGE_API_KEY`: API key for Alpha Vantage
+- `FMP_API_KEY`: API key for FinancialModelingPrep (used for stock search)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- handle missing FMP API key gracefully
- mention FMP_API_KEY variable in README

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841244dcc8083298df582ab35edec94